### PR TITLE
overlay: show "slow charge" if current less than 600 mA.

### DIFF
--- a/overlay/frameworks/base/packages/Keyguard/res/values/config.xml
+++ b/overlay/frameworks/base/packages/Keyguard/res/values/config.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+/*
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License");
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<!-- These resources are around just to allow their values to be customized -->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- Threshold in micro amperes below which a charger is rated as "slow" -->
+    <integer name="config_chargingSlowlyThreshold">600000</integer>
+
+</resources>


### PR DESCRIPTION
Change-Id: Icc488621d17abccf2de7042dd708e574772eed5e
